### PR TITLE
Fix subprocess.check_output error

### DIFF
--- a/core/utils/change_solc_version.py
+++ b/core/utils/change_solc_version.py
@@ -4,7 +4,7 @@ from typing import List
 
 def change_solc_version(sol_path:str):
     # 获取已有的solc版本
-    res = subprocess.check_output('solc-select versions')
+    res = subprocess.check_output(['solc-select', 'versions'])
     versions = []
     cur_version = ''
     for item in res.splitlines():


### PR DESCRIPTION
``` python
Python 3.10.4 (main, Jun 29 2022, 12:14:53) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import subprocess
>>> subprocess.check_output('solc-select versions')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 501, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.10/subprocess.py", line 966, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1842, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'solc-select versions'
>>> subprocess.check_output(['solc-select', 'versions'])
b'0.4.25 (current, set by /root/.solc-select/global-version)\n'
```